### PR TITLE
Fixes #7 opencv_python version 4.5.* causes in wrong rotation of images

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-numpy>=1.18
-img2pdf>=0.4.0
-pyocr==0.7.2
-opencv_python>=4.4.0
-Pillow>=7.2.0
-Unidecode==1.1.1
+numpy==1.22.*
+img2pdf==0.4.*
+pyocr==0.7.*
+opencv_python==4.4.*
+Pillow==9.0.*
+Unidecode==1.1.*


### PR DESCRIPTION
Set a fixed version of 4.4.* for opencv_python and update the other dependencies.